### PR TITLE
A 1st version API spec

### DIFF
--- a/jmri_api.md
+++ b/jmri_api.md
@@ -1,20 +1,17 @@
 Type | Name | Status | Force
 ---- | ---- | ------ | -----
-package | jmri | MAINTAINED
 package | jmri.** | MAINTAINED
 
-package | jmri.beans | MAINTAINED
-package | jmri.configurexml | INTERNAL
-package | jmri.implementation | INTERNAL
-package | jmri.jmris | MAINTAINED
+package | jmri.beans.** | MAINTAINED
+package | jmri.configurexml.** | INTERNAL
+package | jmri.implementation.** | INTERNAL
+package | jmri.jmris.** | MAINTAINED
 
-package | jmri.jmrit | MAINTAINED
+package | jmri.jmrit.** | MAINTAINED
 
-  package | jmri.jmrit.decoderdefn | MAINTAINED
   package | jmri.jmrit.decoderdefn.** | MAINTAINED
   class   | jmri.jmrit.decoderdefn.DecoderIndexFile | INTERNAL
 
-  package | jmri.jmrit.beantable | INTERNAL
   package | jmri.jmrit.beantable.** | INTERNAL
   class   | jmri.jmrit.beantable.AudioTableAction| MAINTAINED
   class   | jmri.jmrit.beantable.BeanTableStartupActionFactory| MAINTAINED
@@ -45,19 +42,16 @@ package | jmri.jmrit | MAINTAINED
   class   | jmri.jmrit.beantable.TurnoutTableAction| MAINTAINED
   class   | jmri.jmrit.beantable.TurnoutTableTabAction| MAINTAINED
 
-  package | jmri.jmrit.conditional | INTERNAL
   package | jmri.jmrit.conditional.** | INTERNAL
 
-  package | jmri.jmrit.display | INTERNAL
   package | jmri.jmrit.display.** | INTERNAL
-  class   | jmri.jmrit.display.NewPanelAction
-  class   | jmri.jmrit.display.controlPanelEditor.ControlPanelEditorAction
-  class   | jmri.jmrit.display.layoutEditor.LayoutEditorAction
-  class   | jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction
-  class   | jmri.jmrit.display.panelEditor.PanelEditorAction
-  class   | jmri.jmrit.display.switchboardEditor.SwitchboardEditorAction
+  class   | jmri.jmrit.display.NewPanelAction | MAINTAINED
+  class   | jmri.jmrit.display.controlPanelEditor.ControlPanelEditorAction | MAINTAINED
+  class   | jmri.jmrit.display.layoutEditor.LayoutEditorAction | MAINTAINED
+  class   | jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction | MAINTAINED
+  class   | jmri.jmrit.display.panelEditor.PanelEditorAction | MAINTAINED
+  class   | jmri.jmrit.display.switchboardEditor.SwitchboardEditorAction | MAINTAINED
 
-  package | jmri.jmrit.roster | INTERNAL
   package | jmri.jmrit.roster.** | INTERNAL
   class   | jmri.jmrit.roster.Roster | MAINTAINED
   class   | jmri.jmrit.roster.RosterConfigManager | MAINTAINED
@@ -89,23 +83,22 @@ package | jmri.jmrit | MAINTAINED
   class   | jmri.jmrit.symbolicprog.tabbedframe.PaneProgAction | MAINTAINED
   class   | jmri.jmrit.symbolicprog.tabbedframe.ProgCheckAction | MAINTAINED
 
-  package | jmri.jmrit.ussctc | INTERNAL
   package | jmri.jmrit.ussctc.** | INTERNAL
 
-package | jmri.jmrix | MAINTAINED
+package | jmri.jmrix.** | MAINTAINED
 
   package | jmri.jmrix.** | INTERNAL
   class   | jmri.jmrix.ConnectionConfig | MAINTAINED
   class   | jmri.jmrix.ConnectionConfigManager | MAINTAINED
   class   | jmri.jmrix.ConnectionStatus | MAINTAINED
 
-package | jmri.managers | INTERNAL
-package | jmri.plaf | INTERNAL
-package | jmri.profile | MAINTAINED
-package | jmri.progdebugger | INTERNAL
-package | jmri.script | INTERNAL
-package | jmri.server | MAINTAINED
-package | jmri.spi | MAINTAINED
-package | jmri.swing | INTERNAL
-package | jmri.util | INTERNAL
-package | jmri.web | MAINTAINED
+package | jmri.managers.** | INTERNAL
+package | jmri.plaf.** | INTERNAL
+package | jmri.profile.** | MAINTAINED
+package | jmri.progdebugger.** | INTERNAL
+package | jmri.script.** | INTERNAL
+package | jmri.server.** | MAINTAINED
+package | jmri.spi.** | MAINTAINED
+package | jmri.swing.** | INTERNAL
+package | jmri.util.** | INTERNAL
+package | jmri.web.** | MAINTAINED

--- a/jmri_api.md
+++ b/jmri_api.md
@@ -1,4 +1,111 @@
 Type | Name | Status | Force
 ---- | ---- | ------ | -----
-package | jmri.** | EXPERIMENTAL | X
 package | jmri | MAINTAINED
+package | jmri.** | MAINTAINED
+
+package | jmri.beans | MAINTAINED
+package | jmri.configurexml | INTERNAL
+package | jmri.implementation | INTERNAL
+package | jmri.jmris | MAINTAINED
+
+package | jmri.jmrit | MAINTAINED
+
+  package | jmri.jmrit.decoderdefn | MAINTAINED
+  package | jmri.jmrit.decoderdefn.** | MAINTAINED
+  class   | jmri.jmrit.decoderdefn.DecoderIndexFile | INTERNAL
+
+  package | jmri.jmrit.beantable | INTERNAL
+  package | jmri.jmrit.beantable.** | INTERNAL
+  class   | jmri.jmrit.beantable.AudioTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.BeanTableStartupActionFactory| MAINTAINED
+  class   | jmri.jmrit.beantable.BlockTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.IdTagTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.IdTagTableTabAction| MAINTAINED
+  class   | jmri.jmrit.beantable.LRouteTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.LightTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.LightTableTabAction| MAINTAINED
+  class   | jmri.jmrit.beantable.ListedTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.LogixTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.MemoryTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.OBlockTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.RailComTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.ReporterTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.ReporterTableTabAction| MAINTAINED
+  class   | jmri.jmrit.beantable.RouteTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SectionTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SensorTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SensorTableTabAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SetPhysicalLocationAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SignalGroupSubTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SignalGroupTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SignalHeadTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SignalMastLogicTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.SignalMastTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.TransitTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.TurnoutTableAction| MAINTAINED
+  class   | jmri.jmrit.beantable.TurnoutTableTabAction| MAINTAINED
+
+  package | jmri.jmrit.conditional | INTERNAL
+  package | jmri.jmrit.conditional.** | INTERNAL
+
+  package | jmri.jmrit.display | INTERNAL
+  package | jmri.jmrit.display.** | INTERNAL
+  class   | jmri.jmrit.display.NewPanelAction
+  class   | jmri.jmrit.display.controlPanelEditor.ControlPanelEditorAction
+  class   | jmri.jmrit.display.layoutEditor.LayoutEditorAction
+  class   | jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction
+  class   | jmri.jmrit.display.panelEditor.PanelEditorAction
+  class   | jmri.jmrit.display.switchboardEditor.SwitchboardEditorAction
+
+  package | jmri.jmrit.roster | INTERNAL
+  package | jmri.jmrit.roster.** | INTERNAL
+  class   | jmri.jmrit.roster.Roster | MAINTAINED
+  class   | jmri.jmrit.roster.RosterConfigManager | MAINTAINED
+  class   | jmri.jmrit.roster.RosterConfigPane | MAINTAINED
+  class   | jmri.jmrit.roster.RosterEntry | MAINTAINED
+
+  package | jmri.jmrit.symbolicprog.** | INTERNAL
+  class   | jmri.jmrit.symbolicprog.CombinedLocoSelListPane | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.CombinedLocoSelPane | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.CombinedLocoSelTreePane | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.CsvExportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.CsvImportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.DccAddressPanel | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.FactoryResetAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.LocoSelPane | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.LocoSelTreePane | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.LokProgImportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.NewLocoSelPane | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.Pr1ExportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.Pr1ImportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.Pr1WinExportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.PrintAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.PrintCvAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.Qualifier | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.QuantumCvMgrImportAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.tabbedframe.PaneEditAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.tabbedframe.PaneNewProgAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.tabbedframe.PaneOpsProgAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.tabbedframe.PaneProgAction | MAINTAINED
+  class   | jmri.jmrit.symbolicprog.tabbedframe.ProgCheckAction | MAINTAINED
+
+  package | jmri.jmrit.ussctc | INTERNAL
+  package | jmri.jmrit.ussctc.** | INTERNAL
+
+package | jmri.jmrix | MAINTAINED
+
+  package | jmri.jmrix.** | INTERNAL
+  class   | jmri.jmrix.ConnectionConfig | MAINTAINED
+  class   | jmri.jmrix.ConnectionConfigManager | MAINTAINED
+  class   | jmri.jmrix.ConnectionStatus | MAINTAINED
+
+package | jmri.managers | INTERNAL
+package | jmri.plaf | INTERNAL
+package | jmri.profile | MAINTAINED
+package | jmri.progdebugger | INTERNAL
+package | jmri.script | INTERNAL
+package | jmri.server | MAINTAINED
+package | jmri.spi | MAINTAINED
+package | jmri.swing | INTERNAL
+package | jmri.util | INTERNAL
+package | jmri.web | MAINTAINED


### PR DESCRIPTION
This is a first version, for conversation, of an API spec.

The approach in e.g. jmrit.symbolicprog, is to mark those classes that might be used externally to jmrit, either in apps or in a user program, as MAINTAINED, and mark everything else as INTERNAL

This is far from complete:  There are a bunch of *Action classes deep in jmri.jmrix.** that haven't been called out as MAINTAINED.  But it's a start.