### PR TITLE
jmrix in API doc draft

### DIFF
--- a/jmri_api.md
+++ b/jmri_api.md
@@ -85,9 +85,7 @@ package | jmri.jmrit.** | MAINTAINED
 
   package | jmri.jmrit.ussctc.** | INTERNAL
 
-package | jmri.jmrix.** | MAINTAINED
-
-  package | jmri.jmrix.** | INTERNAL
+package | jmri.jmrix.** | INTERNAL
   class   | jmri.jmrix.ConnectionConfig | MAINTAINED
   class   | jmri.jmrix.ConnectionConfigManager | MAINTAINED
   class   | jmri.jmrix.ConnectionStatus | MAINTAINED


### PR DESCRIPTION
Fix double definition of jmri.jmrix

Not clear how to handle many of the classes in jmri.jmrix.  If somebody adds a new connection type of their own, these should n't be INTERNAL.  But that really doesn't happen a lot, and these do evolve...